### PR TITLE
fix range check exception when the input tensor is double of any scalar

### DIFF
--- a/source/onnxruntime.pas
+++ b/source/onnxruntime.pas
@@ -2460,7 +2460,8 @@ end;
 function TORTTensorTypeAndShapeInfoHelper.GetShape: TArray<int64_t>;
 begin
   setLength(result,GetDimensionsCount());
-  GetDimensions(@result[0], length(result));
+  if GetDimensionsCount()>0 then
+    GetDimensions(@result[0], length(result));
 end;
 
 { TSessionHelper }


### PR DESCRIPTION
When the input tensor is a scalar, an exception will be thrown when calling `GetShape`.